### PR TITLE
Fix csq columns extraction

### DIFF
--- a/src/csq_selector.nim
+++ b/src/csq_selector.nim
@@ -7,6 +7,7 @@ import os
 import streams
 import re
 import json
+import sequtils
 import std/sets
 import csq_selector/impact_order
 import csq_selector/utils
@@ -14,7 +15,7 @@ import csq_selector/tx_expression
 import csq_selector/split_ann
 import csq_selector/arg_parse
 
-const VERSION = "0.4.2"
+const VERSION = "0.4.3"
 const TSV_HEADER = "#CHROM\tPOS\tID\tREF\tALT\tFILTER\tGENE_ID\tGENE_SYMBOL\tTRANSCRIPT\tCONSEQUENCE\tTAGGED_CSQ\tRENAMED_TAGGED_CSQ"
 
 proc write_new_var(wrt:VCF, v:Variant): bool {.inline.} =
@@ -221,7 +222,8 @@ proc main* () =
     #csq_config.most_expressed: bool # not implemented yet
     csq_config.group_by_gene = by_gene
     csq_config.tagging_config = tag_config_json
-    csq_config.csq_output_fields = csq_columns
+    # Make csq columns all to uppercase for consistency
+    csq_config.csq_output_fields = csq_columns.map(proc(x: string): string = x.toUpperAscii)
     csq_config.tx_vers_re = TX_VERS_RE
     csq_config.rename_schema = rename_dict
 

--- a/src/csq_selector/split_ann.nim
+++ b/src/csq_selector/split_ann.nim
@@ -110,6 +110,7 @@ proc get_most_severe*(csqs:seq[Impact], by_gene: bool): seq[Impact] =
 
 #Split consequences from ANN/CSQ/BCSQ and returns a list of csq as Impact object
 proc split_csqs*(v:Variant, config: Config, impact_order: TableRef[string, int], unknown_impacts: var HashSet[string]): (bool, seq[Impact]) =
+  log("DEBUG", fmt"Processing variant {v.CHROM}:{v.POS}:{v.REF}>{v.ALT[0]} for csq splitting")
   let field_indexes = config.csq_field_idxs
   var max_impact_order = 99
   if config.min_impact != "":
@@ -271,6 +272,8 @@ proc split_csqs*(v:Variant, config: Config, impact_order: TableRef[string, int],
           csq_table[k] = toks[v]
         x.csq_fields = csq_table
 
+        log("DEBUG", fmt"Parsed impact: {$x}")
+        log("DEBUG", fmt"CSQ fields: {x.csq_fields}")
         parsed_impacts.add(x)
 
     if parsed_impacts.len > 0 and config.most_severe:
@@ -358,6 +361,7 @@ proc get_csq_string*(csqs: seq[Impact], csq_columns: seq[string], format: string
   ## Adapt this to be able to output TSV format
 
   for x in csqs:
+    log("DEBUG", fmt"Generating output for impact: {x}")
     var impact_str = x.impact
     var renamed_str = x.renamed_csq
     if x.tag_suffix.len > 0:
@@ -377,8 +381,11 @@ proc get_csq_string*(csqs: seq[Impact], csq_columns: seq[string], format: string
           impact_str,
           renamed_str
         ]
+        log("DEBUG", fmt"Main line before adding extra columns: {line}")
         for c in csq_columns:
-          line.add(x.csq_fields.getOrDefault(c, "."))
+          let column_value = x.csq_fields.getOrDefault(c, ".")
+          log("DEBUG", fmt"Adding column {c} with value '{column_value}'")
+          line.add(column_value)
         result.add(line.join("\t"))
       of "vcf":
         result.add(x.csq_string)

--- a/src/csq_selector/split_ann.nim
+++ b/src/csq_selector/split_ann.nim
@@ -110,7 +110,7 @@ proc get_most_severe*(csqs:seq[Impact], by_gene: bool): seq[Impact] =
 
 #Split consequences from ANN/CSQ/BCSQ and returns a list of csq as Impact object
 proc split_csqs*(v:Variant, config: Config, impact_order: TableRef[string, int], unknown_impacts: var HashSet[string]): (bool, seq[Impact]) =
-  log("DEBUG", fmt"Processing variant {v.CHROM}:{v.POS}:{v.REF}>{v.ALT[0]} for csq splitting")
+  #log("DEBUG", fmt"Processing variant {v.CHROM}:{v.POS}:{v.REF}>{v.ALT[0]} for csq splitting")
   let field_indexes = config.csq_field_idxs
   var max_impact_order = 99
   if config.min_impact != "":
@@ -272,8 +272,8 @@ proc split_csqs*(v:Variant, config: Config, impact_order: TableRef[string, int],
           csq_table[k] = toks[v]
         x.csq_fields = csq_table
 
-        log("DEBUG", fmt"Parsed impact: {$x}")
-        log("DEBUG", fmt"CSQ fields: {x.csq_fields}")
+        #log("DEBUG", fmt"Parsed impact: {$x}")
+        #log("DEBUG", fmt"CSQ fields: {x.csq_fields}")
         parsed_impacts.add(x)
 
     if parsed_impacts.len > 0 and config.most_severe:
@@ -361,7 +361,7 @@ proc get_csq_string*(csqs: seq[Impact], csq_columns: seq[string], format: string
   ## Adapt this to be able to output TSV format
 
   for x in csqs:
-    log("DEBUG", fmt"Generating output for impact: {x}")
+    #log("DEBUG", fmt"Generating output for impact: {x}")
     var impact_str = x.impact
     var renamed_str = x.renamed_csq
     if x.tag_suffix.len > 0:
@@ -381,10 +381,10 @@ proc get_csq_string*(csqs: seq[Impact], csq_columns: seq[string], format: string
           impact_str,
           renamed_str
         ]
-        log("DEBUG", fmt"Main line before adding extra columns: {line}")
+        #log("DEBUG", fmt"Main line before adding extra columns: {line}")
         for c in csq_columns:
           let column_value = x.csq_fields.getOrDefault(c, ".")
-          log("DEBUG", fmt"Adding column {c} with value '{column_value}'")
+          #log("DEBUG", fmt"Adding column {c} with value '{column_value}'")
           line.add(column_value)
         result.add(line.join("\t"))
       of "vcf":


### PR DESCRIPTION
This resolves an issue with extracting custom CSQ columns. Column names are now normalized to upper case when loading them, and the column names requested by the user are also converted to upper case to ensure consistency.